### PR TITLE
Wires and Blocks saved with an id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ export_presets.cfg
 .mono/
 data_*/
 mono_crash.*.json
+Logic Sim/LICENSE.md
+Logic Sim/README.md

--- a/Logic Sim/icon.svg.import
+++ b/Logic Sim/icon.svg.import
@@ -2,7 +2,7 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://dcl5nl2dx7u6h"
+uid="uid://bc45c1rdeu7un"
 path="res://.godot/imported/icon.svg-218a8f2b3041327d8a5756f3a245f83b.ctex"
 metadata={
 "vram_texture": false

--- a/Logic Sim/project.godot
+++ b/Logic Sim/project.godot
@@ -30,6 +30,10 @@ window/stretch/mode="canvas_items"
 window/stretch/aspect="ignore"
 display_server/driver.linuxbsd="wayland"
 
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/godot-vim/plugin.cfg", "res://addons/godot_vim/plugin.cfg")
+
 [global_group]
 
 wire_area=""

--- a/Logic Sim/scripts/block.gd
+++ b/Logic Sim/scripts/block.gd
@@ -1,3 +1,4 @@
+#TODO: The naming of input and output terminal has to be refined since it seems to be switched in some places
 extends Node2D
 class_name Block
 
@@ -23,8 +24,8 @@ class_name Block
 var terminal_height: float
 var block_height: float
 var block_width: float
-
 var placement_offset: Vector2 = Vector2.ZERO
+var id: int
 
 func setup_step_one() -> void:
 	set_meta('type', 'block')

--- a/Logic Sim/scripts/builder_ui.gd
+++ b/Logic Sim/scripts/builder_ui.gd
@@ -50,20 +50,22 @@ func _ready():
 
 func instantiate_block(scene: PackedScene):
 	var instance = scene.instantiate()
-	instance.name = str(builder.block_count)
 	instance.build_mode = true
 
-	builder.block_count += 1
+	instance.name = str(builder.block_id_counter)
+	instance.id = builder.block_id_counter
+	builder.block_id_counter += 1
+	
 	builder.blocks.add_child(instance)
 
 	multi_placement_behavior(instance)
 
 func instantiate_wire():
 	var instance = wire_scene.instantiate()
-	instance.name = str(builder.wire_count)
-	builder.wire_count += 1
+	instance.name = str(builder.wire_id_counter)
+	instance.id = builder.wire_id_counter
+	builder.wire_id_counter += 1
 	builder.wires.add_child(instance)
-
 
 func _on_name_text_changed(new_text:String) -> void:
 	builder.built_block_name = new_text
@@ -94,12 +96,15 @@ func _on_delete_confirmed(block_path: String) -> void:
 func instantiate_custom_block(block_path: String):
 	var block_data = JSON.parse_string(FileAccess.open(block_path, FileAccess.READ).get_as_text())
 	var instance: CustomBlock = custom_block.instantiate()
-	instance.name = str(builder.block_count)
+
 	instance.build_mode = true
 	instance.block_data = block_data
 	custom_buttons_to_blocks[block_path].append(instance)
-
-	builder.block_count += 1
+	
+	instance.name = str(builder.block_id_counter)
+	instance.id = builder.block_id_counter
+	builder.block_id_counter += 1
+	
 	builder.blocks.add_child(instance)
 
 	multi_placement_behavior(instance)
@@ -138,9 +143,6 @@ func _on_clear_confirmed():
 	builder.all_terminals.clear()
 	builder.input_terminals.clear()
 	builder.output_terminals.clear()
-
-	builder.terminal_id_counter = 0
-	builder.block_count = 0
 
 func edit_builder_layout() -> void:
 	Global.edit_mode = true

--- a/Logic Sim/scripts/globals/helpers.gd
+++ b/Logic Sim/scripts/globals/helpers.gd
@@ -38,3 +38,10 @@ func terminal_sorting_helper_axis_x(a,b) -> bool:
 	return a.global_position.x < b.global_position.x
 func terminal_sorting_helper_axis_y(a,b) -> bool:
 	return a.global_position.y < b.global_position.y
+
+func make_array_unique(input: Array) -> Array:
+	var output: Array = []
+	for element in input:
+		if output.has(element): continue
+		output.append(element)
+	return output


### PR DESCRIPTION
The saving system is now the same for all kinds of parts. This way the id counter for terminals, blocks and wires is saved. Additionally the other points of wires are also saved.